### PR TITLE
I changed the jdk version 13 to 8 for proper execution of mvn commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>13</maven.compiler.source>
-        <maven.compiler.target>13</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
 


### PR DESCRIPTION
for mvn commands execution jdk 8 might be more proper than the other one therefore I wanted to change it 13 to 8.